### PR TITLE
[DEV-1876] Update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ Devise.setup do |config|
   config.jwt_cookie do |jwt_cookie|
     # ...
     jwt_cookie.secure = false if Rails.env.development?
+    jwt_cookie.domain = "yourdomain.com"
   end
 end
 ```
+
+`jwt_cookie.domain` will default to `localhost:3000'.
 
 #### name
 
@@ -52,7 +55,7 @@ The name of the cookie. Defaults to `access_token`.
 
 #### domain
 
-The domain the cookie should be issued to. Will be omitted if not set.
+The domain the cookie should be issued to. Defaults to `localhost:3000`.
 
 #### secure
 

--- a/lib/devise/jwt/cookie.rb
+++ b/lib/devise/jwt/cookie.rb
@@ -14,9 +14,9 @@ module Devise
     module Cookie
       extend Dry::Configurable
 
-      setting :name, 'access_token'
-      setting :secure, true
-      setting :domain
+      setting :name, default: 'access_token'
+      setting :secure, default: true
+      setting :domain, default: 'localhost:3000'
 
       Import = Dry::AutoInject(config)
     end

--- a/lib/devise/jwt/cookie.rb
+++ b/lib/devise/jwt/cookie.rb
@@ -16,7 +16,7 @@ module Devise
 
       setting :name, default: 'access_token'
       setting :secure, default: true
-      setting :domain, default: 'localhost:3000'
+      setting :domain
 
       Import = Dry::AutoInject(config)
     end


### PR DESCRIPTION
[DEV-1876](https://outfund.atlassian.net/browse/DEV-1876)

Updating the default to resolve the error

```
/home/sbl/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/devise-jwt-cookie-df2c8f2a6d97/lib/devise/jwt/cookie.rb:14:in `<module:JWT>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
2Provide a `default:` keyword argument instead
```