### PR TITLE
[DEV-1876] - Update to dependancies, version and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'devise-jwt-cookie', '~> 0.5.5'
+gem 'devise-jwt-cookie', '~> 0.5.6'
 ```
 
 And then execute:
@@ -47,15 +47,13 @@ Devise.setup do |config|
 end
 ```
 
-`jwt_cookie.domain` will default to `localhost:3000'.
-
 #### name
 
 The name of the cookie. Defaults to `access_token`.
 
 #### domain
 
-The domain the cookie should be issued to. Defaults to `localhost:3000`.
+The domain the cookie should be issued to. You can set this to your domain.
 
 #### secure
 

--- a/devise-jwt-cookie.gemspec
+++ b/devise-jwt-cookie.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'devise-jwt', '~> 0.6'
-  spec.add_dependency 'dry-auto_inject', '~> 0.6'
-  spec.add_dependency 'dry-configurable', '~> 0.9', '< 0.11'
+  spec.add_dependency 'devise-jwt', '~> 0.9'
+  spec.add_dependency 'dry-auto_inject', '~> 0.9'
+  spec.add_dependency 'dry-configurable', '~> 0.15.0'
 
   spec.add_development_dependency "bundler", "> 1"
   spec.add_development_dependency "rake", "~> 12.3"

--- a/lib/devise/jwt/cookie/version.rb
+++ b/lib/devise/jwt/cookie/version.rb
@@ -1,7 +1,7 @@
 module Devise
   module JWT
     module Cookie
-      VERSION = '0.5.5'
+      VERSION = '0.5.6'
     end
   end
 end


### PR DESCRIPTION
[Task](https://outfund.atlassian.net/browse/DEV-1876)

We were getting 2 errors relating to the way the defaults are being set currently.

```
`<module:JWT>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```

To resolve this we have updated how the defaults are set on the gem as per the updates to `dry-configurable`